### PR TITLE
Switch badges for rockets conditional

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,5 +15,5 @@
 }
 
 .height {
-  height: 200px;
+  height: 230px;
 }

--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -14,6 +14,12 @@ const Rocket = ({ rocket }) => {
       <div className="w-75 gap-2">
         <h2>{rocketName}</h2>
         <p>
+          {
+            reserved ? (
+              <span className="btn btn-info btn-sm mx-2 h-1">Reserved</span>
+            )
+              : ('')
+          }
           {description}
         </p>
         {


### PR DESCRIPTION
### In this pull request I have done the following changes:
- Rockets that have already been reserved showed a "Reserved" badge and a "Cancel reservation" button instead of the default "Reserve rocket" (as per design).

![image](https://user-images.githubusercontent.com/104406349/217594503-4345fdf6-daeb-4951-92f3-227bca8a01c1.png)

- I used  the React conditional rendering syntax: